### PR TITLE
Group alerts by machine class

### DIFF
--- a/lib/govuk_alert_tracker.rb
+++ b/lib/govuk_alert_tracker.rb
@@ -32,11 +32,7 @@ private
 
   def save_alerts(host, start_date, end_date)
     alerts_to_save(host, start_date, end_date).each do |alert|
-      parsed_host = alert.host
-      parsed_alert = alert.message
-      spreadsheet_poster.append(row: [
-        parsed_host, alert.date, parsed_alert, 1, 1, parsed_alert
-      ])
+      spreadsheet_poster.append(row: [alert.date, alert.host, alert.message])
     end
   end
 

--- a/lib/govuk_alert_tracker.rb
+++ b/lib/govuk_alert_tracker.rb
@@ -33,20 +33,12 @@ private
   def extract_alerts(host, start_date, end_date)
     alerts = icinga.alerts(host, start_date, end_date)
     alerts.each do |alert|
-      parsed_host = strip_number_off_host_name(host)
-      parsed_alert = strip_date_and_host(alert)
+      parsed_host = alert.host
+      parsed_alert = alert.message
       spreadsheet_poster.append(row: [
-        parsed_host, alert[1..10], parsed_alert, 1, 1, parsed_alert
+        parsed_host, alert.date, parsed_alert, 1, 1, parsed_alert
       ])
     end
-  end
-
-  def strip_date_and_host(alert)
-    alert.slice(/;.*?(;)/)[1..-2]
-  end
-
-  def strip_number_off_host_name(host)
-    host.sub(/-\d/, '')
   end
 
   def epoch_date(date)

--- a/lib/govuk_alert_tracker.rb
+++ b/lib/govuk_alert_tracker.rb
@@ -31,13 +31,18 @@ private
   end
 
   def save_alerts(host, start_date, end_date)
-    alerts = icinga.alerts(host, start_date, end_date)
-    alerts.each do |alert|
+    alerts_to_save(host, start_date, end_date).each do |alert|
       parsed_host = alert.host
       parsed_alert = alert.message
       spreadsheet_poster.append(row: [
         parsed_host, alert.date, parsed_alert, 1, 1, parsed_alert
       ])
+    end
+  end
+
+  def alerts_to_save(host, start_date, end_date)
+    icinga.alerts(host, start_date, end_date).reject do |alert|
+      alert.message == "gor running"
     end
   end
 

--- a/lib/govuk_alert_tracker.rb
+++ b/lib/govuk_alert_tracker.rb
@@ -8,29 +8,29 @@ require_relative 'spreadsheet_poster'
 class GovukAlertTracker
   def run_report(months)
     script_start_time = Time.now
+
     dates = months_of_the_past(months, script_start_time.strftime("%m-%Y"))
-    p dates
-    monthly_reports = dates.each { |date| alert_report(date) }
+    puts "Dates: #{dates}"
+
+    dates.each { |date| run_month_report(date) }
     spreadsheet_poster.commit
+
     script_duration = Time.now - script_start_time
-    p "script ran in #{Time.at(script_duration).utc.strftime("%H:%M:%S")}"
+    puts "Script ran in #{Time.at(script_duration).utc.strftime("%H:%M:%S")}"
   end
 
 private
 
-  def alert_report(date) #mm-yyyy
-    script_start_time = Time.now
+  def run_month_report(date) # mm-yyyy
     start_date = epoch_date("01-#{date}")
     end_date = end_date(date)
     hosts_list.each do |host|
-      p "#{date} - #{host}"
-      extract_alerts(host, start_date, end_date)
+      puts "#{date} - #{host}"
+      save_alerts(host, start_date, end_date)
     end
-    script_duration = Time.now - script_start_time
-    p "script ran in #{Time.at(script_duration).utc.strftime("%H:%M:%S")} for #{date}"
   end
 
-  def extract_alerts(host, start_date, end_date)
+  def save_alerts(host, start_date, end_date)
     alerts = icinga.alerts(host, start_date, end_date)
     alerts.each do |alert|
       parsed_host = alert.host
@@ -51,7 +51,8 @@ private
     epoch_date("#{Time.days_in_month(month, year)}-#{date}")
   end
 
-  def hosts_list #this list has to be updated manually - it's hard to get it from Icinga as there is no specific url for it.
+  def hosts_list
+    # this list has to be updated manually - it's hard to get it from Icinga as there is no specific url for it
     File.readlines("./list_of_hosts.txt").map(&:strip)
   end
 

--- a/lib/icinga.rb
+++ b/lib/icinga.rb
@@ -25,9 +25,11 @@ private
     "?ts_start=#{start_date}" \
     "&ts_end=#{end_date}" \
     "&host=#{host}.publishing.service.gov.uk" \
-    "&statetype=0" \
+    "&statetype=2" \
     "&type=16" \
     "&nosystem=on" \
+    "&noflapping=on" \
+    "&nodowntime=on" \
     "&limit=1000" \
     "&start=1"
   end

--- a/lib/icinga.rb
+++ b/lib/icinga.rb
@@ -31,6 +31,7 @@ private
   end
 
   def get_log_entries(url)
+    puts "Fetching:", url
     page = Faraday.get(url).body
     html_doc = Nokogiri::HTML(page)
     html_doc.css("div[class='logEntries']")

--- a/lib/icinga.rb
+++ b/lib/icinga.rb
@@ -6,8 +6,12 @@ Alert = Struct.new(:host, :date, :message) do
     host.split("-")[0..-2].join("-")
   end
 
-  def ==(other)
-    self.machine_class == other.machine_class && self.date == other.date && self.message == other.message
+  def eql?(other)
+    machine_class == other.machine_class && date == other.date && message == other.message
+  end
+
+  def hash
+    [machine_class, date, message].hash
   end
 end
 

--- a/lib/icinga.rb
+++ b/lib/icinga.rb
@@ -1,7 +1,15 @@
 require 'faraday'
 require 'nokogiri'
 
-Alert = Struct.new(:host, :date, :message)
+Alert = Struct.new(:host, :date, :message) do
+  def machine_class
+    host.split("-")[0..-2].join("-")
+  end
+
+  def ==(other)
+    self.machine_class == other.machine_class && self.date == other.date && self.message == other.message
+  end
+end
 
 class Icinga
   def alerts(host, start_date, end_date)
@@ -17,7 +25,7 @@ private
   def parse_alert(host, text)
     date = text[1..10]
     message = text.slice(/;.*?(;)/)[1..-2]
-    Alert.new(host, date, message)
+    Alert.new(host.strip, date.strip, message.strip)
   end
 
   def build_url(host, start_date, end_date)

--- a/lib/spreadsheet_poster.rb
+++ b/lib/spreadsheet_poster.rb
@@ -20,7 +20,7 @@ class SpreadsheetPoster
   end
 
   def commit
-    puts "Comitting to spreadsheet..."
+    puts "Comitting #{@pending_rows.count} to spreadsheet..."
     save(@pending_rows)
     @pending_rows = []
   end

--- a/lib/spreadsheet_poster.rb
+++ b/lib/spreadsheet_poster.rb
@@ -20,6 +20,7 @@ class SpreadsheetPoster
   end
 
   def commit
+    puts "Comitting to spreadsheet..."
     save(@pending_rows)
     @pending_rows = []
   end
@@ -29,17 +30,5 @@ private
   def save(array)
     value_range = Google::Apis::SheetsV4::ValueRange.new(values: array)
     @sheets.append_spreadsheet_value(@spreadsheet_id, @range, value_range, value_input_option: "RAW")
-  end
-end
-
-class AccessToken
-  attr_reader :token
-
-  def initialize(token)
-    @token = token
-  end
-
-  def apply!(headers)
-    headers['Authorization'] = "Bearer #{@token}"
   end
 end


### PR DESCRIPTION
This means the spreadsheet will now write the data to the spreadsheet in this format:

| Date | Machine Class | Message | Count |
|-|-|-|-|
| 2018-01-01 | ... | ... | ... |
| ... |

This also refactors the code to be slightly clearer, filters out soft alerts, flapping alerts and alerts that may happen while a machine has recorded downtime.

It also filters out the `gor running` alerts as we don't deem them to be useful.

[Trello Card](https://trello.com/c/serdtvuZ/635-improve-alerting-information-on-the-platform-health-dashboard)